### PR TITLE
feat: translate content to Spanish

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,13 +1,13 @@
 import "./globals.css";
 
 export const metadata = {
-  title: "Happy Anniversary!",
-  description: "A celebration of our love",
+  title: "¡Feliz aniversario!",
+  description: "Una celebración de nuestro amor",
 }
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="es" suppressHydrationWarning>
       <body
         className={`antialiased`}
       >

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -57,22 +57,22 @@ export default function Home() {
 
   // Add your photos here
   const photos = [
-    { src: "/image1.jpg", alt: "You + Me = Always 💑⏱️" },
-    { src: "/image2.jpg", alt: "Special moment" },
-    { src: "/image3.jpg", alt: "Just us — in love, in sync 💑💞" } ,
-    { src: "/image4.jpg", alt: "Us together" },
-    { src: "/image5.jpg", alt: "💖Two hearts, one time — holding on to forever 🕰️❤️🤝" },
-    { src: "/image6.jpg", alt: "Happy times" },
-    { src: "/image7.jpg", alt: "📸 The moment she said ‘I love you too’ — forever captured, forever cherished 💖" },
+    { src: "/image1.jpg", alt: "Tú + Yo, para siempre 💑⏱️" },
+    { src: "/image2.jpg", alt: "Instante especial" },
+    { src: "/image3.jpg", alt: "Solo nosotros, en sintonía 💑💞" },
+    { src: "/image4.jpg", alt: "Juntos" },
+    { src: "/image5.jpg", alt: "Dos corazones, un mismo tiempo 🕰️❤️🤝" },
+    { src: "/image6.jpg", alt: "Momentos felices" },
+    { src: "/image7.jpg", alt: "📸 Cuando dijo 'yo también te amo' 💖" },
   ]
 
   // Change this message according to you
-  const message = `Dear Love,
-This journey with you has been the most beautiful adventure of my life. Every moment spent with you feels like a blessing, and I cherish each day we've been together.
-From our first meeting to today, you've filled my life with joy, laughter, and unconditional love. Your smile brightens my darkest days, and your love gives me strength when I need it most.
-As we celebrate another year together, I want you to know that my love for you grows stronger with each passing day. You are my best friend, my confidant, and my soulmate.
-Happy Anniversary, my love! Here's to many more years of creating beautiful memories together.
-With all my heart,
+  const message = `Mi amor,
+Cada paso a tu lado ha sido la mejor parte de mi historia. Contigo el tiempo se siente ligero y cada día trae una nueva razón para sonreír.
+Desde aquel primer momento hasta hoy, llenas mi mundo de calma, risas y cariño sincero. Tu mirada levanta mis días grises y tu abrazo me hace sentir invencible.
+Hoy celebramos otro año juntos y no puedo evitar amar más todo lo que somos. Gracias por ser mi compañera, mi confidente y mi destino favorito.
+Feliz aniversario. Que sigamos creando recuerdos que hagan brillar el futuro.
+Con todo mi corazón,
 Yash Kewat`
 
   return (
@@ -117,10 +117,10 @@ Yash Kewat`
               <div className="absolute -top-16 -left-16 w-32 h-32 text-5xl animate-float">🌸</div>
               <div className="absolute -bottom-28 -right-14 w-32 h-32 text-5xl animate-float-delay">🌺</div>
 
-              <h1 className="text-4xl md:text-5xl py-1.5 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 mb-4 animate-gradient">
-                Our Anniversary is Coming!
-              </h1>
-              <p className="text-xl text-purple-700 font-medium">The countdown to our special day ❤️</p>
+                <h1 className="text-4xl md:text-5xl py-1.5 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 mb-4 animate-gradient">
+                  ¡Nuestro aniversario está cerca!
+                </h1>
+                <p className="text-xl text-purple-700 font-medium">Cuenta regresiva para nuestro día especial ❤️</p>
             </motion.div>
 
             <Countdown targetDate={ANNIVERSARY_DATE} onComplete={handleCountdownComplete} />
@@ -151,10 +151,10 @@ Yash Kewat`
                   🎊
                 </div>
 
-                <h1 className="text-4xl md:text-6xl py-1 md:py-2 px-6 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 mb-3 animate-gradient">
-                  Happy Anniversary!
-                </h1>
-                <p className="text-xl text-purple-700 font-medium">Every moment with you is a blessing ❤️</p>
+                  <h1 className="text-4xl md:text-6xl py-1 md:py-2 px-6 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 mb-3 animate-gradient">
+                    ¡Feliz aniversario!
+                  </h1>
+                  <p className="text-xl text-purple-700 font-medium">Cada momento contigo es un regalo ❤️</p>
               </motion.div>
 
               <DaysTogether startDate={TOGETHER_DATE} animationDuration={3} />
@@ -169,7 +169,7 @@ Yash Kewat`
                 transition={{ delay: 1.5 }}
                 className="text-center mt-16 mb-8 text-pink-600"
               >
-                <p className="text-lg font-medium">Made with ❤️ by YASH KEWAT</p>
+                <p className="text-lg font-medium">Hecho con ❤️ por YASH KEWAT</p>
               </motion.footer>
             </motion.div>
           </>

--- a/src/components/Countdown.jsx
+++ b/src/components/Countdown.jsx
@@ -44,10 +44,10 @@ export default function Countdown({ targetDate, onComplete }) {
     }, [targetDate, onComplete])
 
     const timeUnits = [
-        { label: "Days", value: timeLeft.days, emoji: "🌞" },
-        { label: "Hours", value: timeLeft.hours, emoji: "⏰" },
-        { label: "Minutes", value: timeLeft.minutes, emoji: "⌛" },
-        { label: "Seconds", value: timeLeft.seconds, emoji: "✨" },
+        { label: "Días", value: timeLeft.days, emoji: "🌞" },
+        { label: "Horas", value: timeLeft.hours, emoji: "⏰" },
+        { label: "Minutos", value: timeLeft.minutes, emoji: "⌛" },
+        { label: "Segundos", value: timeLeft.seconds, emoji: "✨" },
     ]
 
     const containerVariants = {
@@ -174,7 +174,7 @@ export default function Countdown({ targetDate, onComplete }) {
                 animate={{ opacity: 1 }}
                 transition={{ delay: 1 }}
             >
-                Until our special day ❤️
+                Hasta nuestro día especial ❤️
             </motion.p>
         </div>
     )

--- a/src/components/DaysTogether.jsx
+++ b/src/components/DaysTogether.jsx
@@ -81,7 +81,7 @@ export default function DaysTogether({ startDate, animationDuration = 3 }) {
                     transition={{ delay: 0.3 }}
                     className="text-3xl md:text-4xl md:py-1 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 text-center mb-10 animate-gradient"
                 >
-                    Our Beautiful Journey Together
+                    Nuestro viaje juntos
                 </motion.h2>
 
                 <div className="flex flex-col items-center justify-center">
@@ -134,7 +134,7 @@ export default function DaysTogether({ startDate, animationDuration = 3 }) {
                         transition={{ delay: 0.5 }}
                         className="text-2xl md:text-3xl text-pink-500 font-medium mb-8"
                     >
-                        Beautiful Days Together
+                        Días increíbles juntos
                     </motion.div>
 
                     <motion.div
@@ -150,8 +150,8 @@ export default function DaysTogether({ startDate, animationDuration = 3 }) {
                         transition={{ delay: 1.2 }}
                         className="text-center text-lg text-gray-600 max-w-2xl"
                     >
-                        Every single day has been a blessing. From our first hello to today, each moment with you has been magical.
-                        Here's to countless more days filled with love, laughter, and beautiful memories!
+                        Cada día a tu lado es un regalo. Desde nuestro primer "hola" hasta hoy, estar contigo es pura magia.
+                        Brindemos por muchos más días llenos de amor, risas y recuerdos inolvidables.
                     </motion.p>
 
                     <motion.div

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -103,7 +103,7 @@ export default function Loader() {
                             ease: "easeInOut",
                         }}
                     >
-                        Loading our love story...
+                        Cargando nuestra historia de amor...
                     </motion.p>
 
                     <motion.div

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -49,7 +49,7 @@ export default function Message({ message }) {
                 transition={{ delay: 0.3 }}
                 className="text-3xl md:text-4xl md:py-1 font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 text-center mb-10 animate-gradient"
             >
-                A Letter From My Heart
+                Una carta de mi corazón
             </motion.h2>
 
             <motion.div

--- a/src/components/MusicPlayer.jsx
+++ b/src/components/MusicPlayer.jsx
@@ -60,7 +60,7 @@ export default function MusicPlayer({ playSong }) {
                 whileTap={{ scale: 0.9 }}
                 onClick={togglePlayback}
                 className="bg-white/80 rounded-full cursor-pointer p-3 shadow-lg flex items-center justify-center text-pink-600 hover:bg-pink-50 transition-colors"
-                aria-label={isPlaying ? "Pause music" : "Play music"}
+                aria-label={isPlaying ? "Pausar música" : "Reproducir música"}
             >
                 <motion.div
                     animate={

--- a/src/components/PhotoGallery.jsx
+++ b/src/components/PhotoGallery.jsx
@@ -69,7 +69,7 @@ export default function PhotoGallery({ photos }) {
                 transition={{ delay: 0.3 }}
                 className="text-3xl md:text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 text-center mb-12 animate-gradient"
             >
-                Our Precious Moments
+                Nuestros momentos más preciados
             </motion.h2>
 
             <motion.div className="flex flex-wrap justify-center gap-10 md:gap-12" >

--- a/src/components/TapToReveal.jsx
+++ b/src/components/TapToReveal.jsx
@@ -79,7 +79,7 @@ export default function TapToReveal({ onReveal }) {
                     </motion.div>
 
                     <motion.h2 className="text-3xl md:text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-purple-500 to-pink-500 animate-gradient">
-                        Your Anniversary Surprise Awaits!
+                        ¡La sorpresa de nuestro aniversario te espera!
                     </motion.h2>
 
                     <motion.div
@@ -93,7 +93,7 @@ export default function TapToReveal({ onReveal }) {
                             ease: "easeInOut",
                         }}
                     >
-                        <span>Tap here to reveal</span>
+                        <span>Toca aquí para descubrir</span>
                         <motion.span
                             animate={{
                                 opacity: [0, 1, 0],


### PR DESCRIPTION
## Summary
- translate homepage text and metadata into Spanish with a cooler romantic tone
- localize component labels, messages and alt text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfb12b6320832884792609dddde7f4